### PR TITLE
-shared flag for non-darwin

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,8 @@ else
     ifeq ($(UNAME_S),Darwin)
         CCFLAGS += -install_name $(LIBNAME) -D OSX
 		LIBFLAGS += -dynamiclib
+	else
+		LIBFLAGS += -shared
     endif
     UNAME_P := $(shell uname -p)
     ifeq ($(UNAME_P),x86_64)
@@ -57,6 +59,7 @@ libstatsdclient.so:	statsd-client.c
 install: lib
 	cp libstatsdclient.so.$(version) $(LIB_DIR)
 	ln -sf $(LIB_DIR)/libstatsdclient.so.$(version) $(LIB_DIR)/$(LIBNAME)
+	ln -sf $(LIB_DIR)/libstatsdclient.so.$(version) $(LIB_DIR)/$(LIBNAME).$(major_version)
 	mkdir -p $(INCLUDE_DIR)
 	cp statsd-client.h $(INCLUDE_DIR)
 


### PR DESCRIPTION
Hi,

there was a bug in Makefile preventing the library from being built on (some) linuxes... It should be ok now on all linux machines.

Thanks
