### PR TITLE
Fix segfault after statsd_init fails

### DIFF
--- a/statsd-client.c
+++ b/statsd-client.c
@@ -20,6 +20,8 @@ statsd_link *statsd_init_with_namespace(const char *host, int port, const char *
     size_t len = strlen(ns_);
 
     statsd_link *temp = statsd_init(host, port);
+    if(!temp)
+        return NULL;
 
     if ( (temp->ns = malloc(len + 2)) == NULL ) {
         perror("malloc");


### PR DESCRIPTION
statsd_init_with_namespace should check the return value of statsd_init. Otherwise we may face a NULL pointer deref and a segfault, eg. when the given statsd server name cannot be resolved.