### PR TITLE
Adding support for sample rates on timing metrics

### DIFF
--- a/statsd-client.c
+++ b/statsd-client.c
@@ -152,7 +152,7 @@ void statsd_prepare(statsd_link *link, char *stat, size_t value, const char *typ
     if (sample_rate == 1.0) {
         snprintf(message, buflen, "%s%s:%zd|%s%s", link->ns ? link->ns : "", stat, value, type, lf ? "\n" : "");
     } else {
-        snprintf(message, buflen, "%s%s:%zd|%s|@%.2f%s", link->ns ? link->ns : "", stat, value, type, sample_rate, lf ? "\n" : "");
+        snprintf(message, buflen, "%s%s:%zd|%s|@%.5f%s", link->ns ? link->ns : "", stat, value, type, sample_rate, lf ? "\n" : "");
     }
 }
 

--- a/statsd-client.c
+++ b/statsd-client.c
@@ -177,7 +177,7 @@ int statsd_gauge(statsd_link *link, char *stat, size_t value)
     return send_stat(link, stat, value, "g", 1.0);
 }
 
-int statsd_timing(statsd_link *link, char *stat, size_t ms)
+int statsd_timing(statsd_link *link, char *stat, size_t ms, float sample_rate)
 {
-    return send_stat(link, stat, ms, "ms", 1.0);
+    return send_stat(link, stat, ms, "ms", sample_rate);
 }

--- a/statsd-client.c
+++ b/statsd-client.c
@@ -177,7 +177,12 @@ int statsd_gauge(statsd_link *link, char *stat, size_t value)
     return send_stat(link, stat, value, "g", 1.0);
 }
 
-int statsd_timing(statsd_link *link, char *stat, size_t ms, float sample_rate)
+int statsd_timing(statsd_link *link, char *stat, size_t ms)
+{
+    return statsd_timing_with_sample_rate(link, stat, ms, 1.0);
+}
+
+int statsd_timing_with_sample_rate(statsd_link *link, char *stat, size_t ms, float sample_rate)
 {
     return send_stat(link, stat, ms, "ms", sample_rate);
 }

--- a/statsd-client.h
+++ b/statsd-client.h
@@ -31,5 +31,6 @@ int statsd_inc(statsd_link *link, char *stat, float sample_rate);
 int statsd_dec(statsd_link *link, char *stat, float sample_rate);
 int statsd_count(statsd_link *link, char *stat, size_t count, float sample_rate);
 int statsd_gauge(statsd_link *link, char *stat, size_t value);
-int statsd_timing(statsd_link *link, char *stat, size_t ms, float sample_rate);
+int statsd_timing(statsd_link *link, char *stat, size_t ms);
+int statsd_timing_with_sample_rate(statsd_link *link, char *stat, size_t ms, float sample_rate);
 #endif

--- a/statsd-client.h
+++ b/statsd-client.h
@@ -31,5 +31,5 @@ int statsd_inc(statsd_link *link, char *stat, float sample_rate);
 int statsd_dec(statsd_link *link, char *stat, float sample_rate);
 int statsd_count(statsd_link *link, char *stat, size_t count, float sample_rate);
 int statsd_gauge(statsd_link *link, char *stat, size_t value);
-int statsd_timing(statsd_link *link, char *stat, size_t ms);
+int statsd_timing(statsd_link *link, char *stat, size_t ms, float sample_rate);
 #endif


### PR DESCRIPTION
I've added support for `sample_rate` on timing metrics as per the StatsD documentation:

https://github.com/etsy/statsd/blob/master/docs/metric_types.md

This is really key when you're timing buffer allocations and so forth and you can't afford to send each one :)
