### PR TITLE
Added support for datadog extensions

### DIFF
--- a/statsd-client.h
+++ b/statsd-client.h
@@ -8,6 +8,7 @@ struct _statsd_link  {
 	struct sockaddr_in server;
 	int sock;
 	char *ns;
+	char *tags;
 };
 
 typedef struct _statsd_link statsd_link;
@@ -15,6 +16,8 @@ typedef struct _statsd_link statsd_link;
 
 statsd_link *statsd_init(const char *host, int port);
 statsd_link *statsd_init_with_namespace(const char *host, int port, const char *ns);
+statsd_link *statsd_init_with_tags(const char *host, int port, const char *tags);
+statsd_link *statsd_init_with_namespace_tags(const char *host, int port, const char *ns, const char *tags);
 void statsd_finalize(statsd_link *link);
 
 /*

--- a/test-client.c
+++ b/test-client.c
@@ -4,7 +4,7 @@
 int main(void)
 {
 
-    statsd_link *link, *link2;
+    statsd_link *link, *link2, *link3;
 
     link = statsd_init("127.0.0.1", 8125);
     statsd_count(link, "count1", 123, 1.0);
@@ -12,15 +12,19 @@ int main(void)
     statsd_count(link, "count2", 125, 1.0);
     statsd_gauge(link, "speed", 10);
     statsd_timing(link2, "request", 2400);
+    link3 = statsd_init_with_tags("127.0.0.1", 8125, "mytag:myvalue");
+    statsd_count(link, "tagcount", 42, 1.0);
     sleep(1);
     statsd_inc(link, "count1", 1.0);
     statsd_dec(link2, "count2", 1.0);
+    statsd_inc(link3, "tagcount", 1.0);
     int i;
     for(i=0; i<10; i++) {
         statsd_count(link2, "count3", i, 0.8);
     }
     statsd_finalize(link);
     statsd_finalize(link2);
+    statsd_finalize(link3);
 
     return 0;
 }

--- a/test-client.c
+++ b/test-client.c
@@ -13,7 +13,7 @@ int main(void)
     statsd_gauge(link, "speed", 10);
     statsd_timing(link2, "request", 2400);
     link3 = statsd_init_with_tags("127.0.0.1", 8125, "mytag:myvalue");
-    statsd_count(link, "tagcount", 42, 1.0);
+    statsd_count(link3, "tagcount", 42, 1.0);
     sleep(1);
     statsd_inc(link, "count1", 1.0);
     statsd_dec(link2, "count2", 1.0);


### PR DESCRIPTION
Really enjoying this to-the-point library!

I have a use-case where I need to use the [datadog tagging extensions](https://docs.datadoghq.com/developers/metrics/dogstatsd_metrics_submission/?tab=python#metric-tagging).

This change produces the following test output:

```shell
$ ./testclient
$ nc -kluv localhost 8125
Bound on localhost 8125
...
tagcount:42|c|#mytag:myvalue
...
tagcount:1|c|#mytag:myvalue
...
```

In case you're curious, I'm not actually using datadog, but the [telegraf-statsd-input plugin](https://github.com/influxdata/telegraf/tree/master/plugins/inputs/statsd). This translates a UDP message such as

```shell
tagcount:1|c|#mytag:myvalue
```
into
```shell
tagcount,mytag=myvalue value=1 1590633814000000000
```
