### PR TITLE
Fix invalid read/write memory issue

### DIFF
--- a/statsd-client.c
+++ b/statsd-client.c
@@ -32,7 +32,7 @@ static int statsd_init_namespace(statsd_link *link, const char* ns_)
 static int statsd_init_tags(statsd_link *link, const char* tags_)
 {
   size_t len = strlen(tags_);
-  if ( (link->tags = malloc(len + 2)) == NULL ) {
+  if ( (link->tags = malloc(len + 3)) == NULL ) {
       perror("malloc");
       return -1;
   }


### PR DESCRIPTION
Really sorry about this, but obviously the buffer I created needs to be `strlen` + *3* since `strlen` doesn't include the `\0` character. 🤦 

### Before Change:
```
ubuntu@mythra:~/Home/statsd-c-client$ valgrind ./test-client 
==2201== Memcheck, a memory error detector
==2201== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==2201== Using Valgrind-3.15.0 and LibVEX; rerun with -h for copyright info
==2201== Command: ./test-client
==2201== 
==2201== Invalid write of size 1
==2201==    at 0x483F0BE: strcpy (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
==2201==    by 0x484B575: statsd_init_tags (in /home/ubuntu/Home/statsd-c-client/libstatsdclient.so.2.0.1)
==2201==    by 0x484B65E: statsd_init_with_tags (in /home/ubuntu/Home/statsd-c-client/libstatsdclient.so.2.0.1)
==2201==    by 0x10932D: main (test-client.c:15)
==2201==  Address 0x4a4b36f is 0 bytes after a block of size 15 alloc'd
==2201==    at 0x483B7F3: malloc (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
==2201==    by 0x484B515: statsd_init_tags (in /home/ubuntu/Home/statsd-c-client/libstatsdclient.so.2.0.1)
==2201==    by 0x484B65E: statsd_init_with_tags (in /home/ubuntu/Home/statsd-c-client/libstatsdclient.so.2.0.1)
==2201==    by 0x10932D: main (test-client.c:15)
==2201== 
==2201== Invalid read of size 1
==2201==    at 0x483EF54: strlen (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
==2201==    by 0x48D1E94: __vfprintf_internal (vfprintf-internal.c:1688)
==2201==    by 0x48E5119: __vsnprintf_internal (vsnprintf.c:114)
==2201==    by 0x48BAF75: snprintf (snprintf.c:31)
==2201==    by 0x484BC43: statsd_prepare (in /home/ubuntu/Home/statsd-c-client/libstatsdclient.so.2.0.1)
==2201==    by 0x484BB33: send_stat (in /home/ubuntu/Home/statsd-c-client/libstatsdclient.so.2.0.1)
==2201==    by 0x484BD18: statsd_count (in /home/ubuntu/Home/statsd-c-client/libstatsdclient.so.2.0.1)
==2201==    by 0x109351: main (test-client.c:16)
==2201==  Address 0x4a4b36f is 0 bytes after a block of size 15 alloc'd
==2201==    at 0x483B7F3: malloc (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
==2201==    by 0x484B515: statsd_init_tags (in /home/ubuntu/Home/statsd-c-client/libstatsdclient.so.2.0.1)
==2201==    by 0x484B65E: statsd_init_with_tags (in /home/ubuntu/Home/statsd-c-client/libstatsdclient.so.2.0.1)
==2201==    by 0x10932D: main (test-client.c:15)
==2201== 
==2201== 
==2201== HEAP SUMMARY:
==2201==     in use at exit: 0 bytes in 0 blocks
==2201==   total heap usage: 8 allocs, 8 frees, 340 bytes allocated
==2201== 
==2201== All heap blocks were freed -- no leaks are possible
==2201== 
==2201== For lists of detected and suppressed errors, rerun with: -s
==2201== ERROR SUMMARY: 3 errors from 2 contexts (suppressed: 0 from 0)
```
### After change:
```
ubuntu@mythra:~/Home/statsd-c-client$ valgrind ./test-client 
==2236== Memcheck, a memory error detector
==2236== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==2236== Using Valgrind-3.15.0 and LibVEX; rerun with -h for copyright info
==2236== Command: ./test-client
==2236== 
==2236== 
==2236== HEAP SUMMARY:
==2236==     in use at exit: 0 bytes in 0 blocks
==2236==   total heap usage: 8 allocs, 8 frees, 341 bytes allocated
==2236== 
==2236== All heap blocks were freed -- no leaks are possible
==2236== 
==2236== For lists of detected and suppressed errors, rerun with: -s
==2236== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```