### PR TITLE
Increase maximum message length to 256 bytes

### DIFF
--- a/statsd-client.c
+++ b/statsd-client.c
@@ -13,7 +13,7 @@
 #define TAG "statsd-client"
 #endif
 
-#define MAX_MSG_LEN 100
+#define MAX_MSG_LEN 256
 
 static int statsd_init_namespace(statsd_link *link, const char* ns_)
 {


### PR DESCRIPTION
The current message size is much too small once multiple tags are in place. 
So increasing it will allow for users to be able to use more tags